### PR TITLE
Default "use 1.0 route" to true, so by default developers will use v1.0

### DIFF
--- a/OneNoteServiceSamplesWinUniversal.Shared/Common/AppSettings.cs
+++ b/OneNoteServiceSamplesWinUniversal.Shared/Common/AppSettings.cs
@@ -22,7 +22,7 @@ namespace OneNoteServiceSamplesWinUniversal.Common
 		{
 			object result = false;
 			ApplicationData.Current.LocalSettings.Values.TryGetValue("UseBeta", out result);
-			return (bool)(result ?? true); // default to true
+			return (bool)(result ?? false); // default to true
 		}
 		public static void SetUseBeta(bool useBeta)
 		{

--- a/OneNoteServiceSamplesWinUniversal.Shared/OneNoteApi/Pages/PatchPagesExample.cs
+++ b/OneNoteServiceSamplesWinUniversal.Shared/OneNoteApi/Pages/PatchPagesExample.cs
@@ -42,7 +42,7 @@ namespace OneNoteServiceSamplesWinUniversal.OneNoteApi.Pages
 
 	/// <summary>
 	/// Class to show a selection of examples updating pages via HTTP PATCH requests to the OneNote API
-	/// Updating an existing page is achieved by sending HTTP PATCH requests to the URL: https://www.onenote.com/api/beta/pages/{id}/content
+	/// Updating an existing page is achieved by sending HTTP PATCH requests to the URL: https://www.onenote.com/api/v1.0/pages/{id}/content
 	/// For more info, see http://dev.onenote.com/docs
 	/// </summary>
 	/// <remarks>
@@ -56,7 +56,7 @@ namespace OneNoteServiceSamplesWinUniversal.OneNoteApi.Pages
 	///  client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
 	///  client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", await Auth.GetAuthToken());
 	/// 
-	///  var createMessage = new HttpRequestMessage(new HttpMethod("PATCH"), "https://www.onenote.com/api/beta/pages/{pageId}/content")
+	///  var createMessage = new HttpRequestMessage(new HttpMethod("PATCH"), "https://www.onenote.com/api/v1.0/pages/{pageId}/content")
 	///  {
 	///      Content = new StringContent("[{ 'target': 'body', 'action': 'append', 'content': '<p>New trailing content</p>' }]", Encoding.UTF8, "application/json")
 	///  };
@@ -64,7 +64,7 @@ namespace OneNoteServiceSamplesWinUniversal.OneNoteApi.Pages
 	/// </code>
 	public static class PatchPagesExample
 	{
-		#region Example of PATCH https://www.onenote.com/api/beta/pages/{id}/content
+		#region Example of PATCH https://www.onenote.com/api/v1.0/pages/{id}/content
 
 		/// <summary>
 		/// Append to the default outline in the content of an existing page

--- a/OneNoteServiceSamplesWinUniversal.Shared/OneNoteApi/SectionGroups/PostSectionGroupsExample.cs
+++ b/OneNoteServiceSamplesWinUniversal.Shared/OneNoteApi/SectionGroups/PostSectionGroupsExample.cs
@@ -32,8 +32,8 @@ namespace OneNoteServiceSamplesWinUniversal.OneNoteApi.SectionGroups
     /// <summary>
     /// Class to show a selection of examples creating section groups via HTTP POST to the OneNote API
     /// - Creating a new section group is represented via the POST HTTP verb.
-    /// - Creating a new section group under a given notebook is represented by the Uri: https://www.onenote.com/api/beta/me/notes/notebooks/{notebookId}/sectiongroups
-    /// - Creating a new section group under a given section group is represented by the Uri: https://www.onenote.com/api/beta/me/notes/sectiongroups/{sectionGroupId}/sectiongroups
+    /// - Creating a new section group under a given notebook is represented by the Uri: https://www.onenote.com/api/v1.0/me/notes/notebooks/{notebookId}/sectiongroups
+    /// - Creating a new section group under a given section group is represented by the Uri: https://www.onenote.com/api/v1.0/me/notes/sectiongroups/{sectionGroupId}/sectiongroups
     /// For more info, see http://dev.onenote.com/docs
     /// </summary>
     /// <remarks>
@@ -56,7 +56,7 @@ namespace OneNoteServiceSamplesWinUniversal.OneNoteApi.SectionGroups
     /// </code>
     public static class PostSectionGroupsExample
     {
-        #region Examples of POST https://www.onenote.com/api/beta/me/notes/notebooks/{notebookId}/sectiongroups
+        #region Examples of POST https://www.onenote.com/api/v1.0/me/notes/notebooks/{notebookId}/sectiongroups
 
         /// <summary>
         ///  BETA Create a section group with a given name under a given notebookId
@@ -100,7 +100,7 @@ namespace OneNoteServiceSamplesWinUniversal.OneNoteApi.SectionGroups
         #endregion
 
 
-        #region Examples of POST https://www.onenote.com/api/beta/me/notes/sectiongroups/{sectionGroupId}/sectiongroups
+        #region Examples of POST https://www.onenote.com/api/v1.0/me/notes/sectiongroups/{sectionGroupId}/sectiongroups
         /// <summary>
         /// BETA Create a section group with a given name under a given sectionGroupId
         /// </summary>

--- a/OneNoteServiceSamplesWinUniversal.Shared/OneNoteApi/Sections/PostSectionsExample.cs
+++ b/OneNoteServiceSamplesWinUniversal.Shared/OneNoteApi/Sections/PostSectionsExample.cs
@@ -33,7 +33,7 @@ namespace OneNoteServiceSamplesWinUniversal.OneNoteApi.Sections
 	/// Class to show a selection of examples creating sections via HTTP POST to the OneNote API
 	/// - Creating a new section is represented via the POST HTTP verb.
     /// - Creating a new section under a given notebook is represented by the Uri: https://www.onenote.com/api/v1.0/me/notes/notebooks/{notebookId}/sections
-    /// - Creating a new section under a given section group is represented by the Uri: https://www.onenote.com/api/beta/me/notes/sectiongroups/{sectionGroupId}/sections
+    /// - Creating a new section under a given section group is represented by the Uri: https://www.onenote.com/api/v1.0/me/notes/sectiongroups/{sectionGroupId}/sections
 	/// For more info, see http://dev.onenote.com/docs
 	/// </summary>
 	/// <remarks>
@@ -99,7 +99,7 @@ namespace OneNoteServiceSamplesWinUniversal.OneNoteApi.Sections
  
         #endregion
 
-        #region Examples of POST https://www.onenote.com/api/beta/me/notes/sectiongroups/{sectionGroupId}/sections
+        #region Examples of POST https://www.onenote.com/api/v1.0/me/notes/sectiongroups/{sectionGroupId}/sections
 
         /// <summary>
         /// BETA Create a section with a given name under a given sectionGroupId


### PR DESCRIPTION
In preparation for shipping to O365 GA, moving APIs to use v1.0 route
